### PR TITLE
[TSS-52] Pull out asserts

### DIFF
--- a/FluentAssertionsEx/Assertions/CancellationTokenAssertions.cs
+++ b/FluentAssertionsEx/Assertions/CancellationTokenAssertions.cs
@@ -1,0 +1,77 @@
+﻿using System.Threading;
+using FluentAssertions;
+using FluentAssertions.Execution;
+
+namespace HivePeople.FluentAssertionsEx.Assertions
+{
+    public class CancellationTokenAssertions
+    {
+        public CancellationToken Subject { get; private set; }
+
+        internal CancellationTokenAssertions(CancellationToken actualCancellationToken)
+        {
+            this.Subject = actualCancellationToken;
+        }
+
+        public AndConstraint<CancellationTokenAssertions> BeEmpty(string because = "", params object[] reasonArgs)
+        {
+            Execute.Assertion
+                .ForCondition(Subject.Equals(CancellationToken.None))
+                .BecauseOf(because, reasonArgs)
+                .FailWith("Expected {context:cancellation token} to be empty (equal default(CancellationToken){reason}.");
+
+            return new AndConstraint<CancellationTokenAssertions>(this);
+        }
+
+        public AndConstraint<CancellationTokenAssertions> NotBeEmpty(string because = "", params object[] reasonArgs)
+        {
+            Execute.Assertion
+                .ForCondition(!Subject.Equals(CancellationToken.None))
+                .BecauseOf(because, reasonArgs)
+                .FailWith("Did not expect {context:cancellation token} to be empty (equal default(CancellationToken){reason}.");
+
+            return new AndConstraint<CancellationTokenAssertions>(this);
+        }
+
+        public AndConstraint<CancellationTokenAssertions> BeCancellable(string because = "", params object[] reasonArgs)
+        {
+            Execute.Assertion
+                .ForCondition(Subject.CanBeCanceled)
+                .BecauseOf(because, reasonArgs)
+                .FailWith("Expected {context:cancellation token} to be cancellable{reason}.");
+
+            return new AndConstraint<CancellationTokenAssertions>(this);
+        }
+
+        public AndConstraint<CancellationTokenAssertions> NotBeCancellable(string because = "", params object[] reasonArgs)
+        {
+            Execute.Assertion
+                .ForCondition(!Subject.CanBeCanceled)
+                .BecauseOf(because, reasonArgs)
+                .FailWith("Did not expect {context:cancellation token} to be cancellable{reason}.");
+
+            return new AndConstraint<CancellationTokenAssertions>(this);
+        }
+
+        public AndConstraint<CancellationTokenAssertions> BeCancelled(string because = "", params object[] reasonArgs)
+        {
+            Execute.Assertion
+                .ForCondition(Subject.IsCancellationRequested)
+                .BecauseOf(because, reasonArgs)
+                .FailWith("Expected {context:cancellation token} to be cancelled{reason}.");
+
+            return new AndConstraint<CancellationTokenAssertions>(this);
+        }
+
+        public AndConstraint<CancellationTokenAssertions> NotBeCancelled(string because = "", params object[] reasonArgs)
+        {
+            Execute.Assertion
+                .ForCondition(!Subject.IsCancellationRequested)
+                .BecauseOf(because, reasonArgs)
+                .FailWith("Did not expect {context:cancellation token} to be cancelled{reason}.");
+
+            return new AndConstraint<CancellationTokenAssertions>(this);
+        }
+    }
+
+}

--- a/FluentAssertionsEx/Assertions/TaskAssertions.cs
+++ b/FluentAssertionsEx/Assertions/TaskAssertions.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+
+namespace HivePeople.FluentAssertionsEx.Assertions
+{
+    public class TaskAssertions
+    {
+        public Task Subject { get; private set; }
+
+        internal TaskAssertions(Task actualTask)
+        {
+            this.Subject = actualTask;
+        }
+
+        public AndConstraint<TaskAssertions> BeCompleted(string because = "", params object[] reasonArgs)
+        {
+            // Freeze actual value, since the status of a task may change during execution
+            var actualStatus = Subject.Status;
+
+            Execute.Assertion
+                .ForCondition(actualStatus == TaskStatus.RanToCompletion || actualStatus == TaskStatus.Faulted || actualStatus == TaskStatus.Canceled)
+                .BecauseOf(because, reasonArgs)
+                .FailWith("Expected {context:task} to be completed{reason}, but its actual status was {0:G}.", actualStatus);
+
+            return new AndConstraint<TaskAssertions>(this);
+        }
+
+        public AndConstraint<TaskAssertions> NotBeCompleted(string because = "", params object[] reasonArgs)
+        {
+            // Freeze actual value, since the status of a task may change during execution
+            var actualStatus = Subject.Status;
+
+            Execute.Assertion
+                .ForCondition(actualStatus != TaskStatus.RanToCompletion && actualStatus != TaskStatus.Faulted && actualStatus != TaskStatus.Canceled)
+                .BecauseOf(because, reasonArgs)
+                .FailWith("Did not expect {context:task} to be completed{reason}, but its actual status was {0:G}.", actualStatus);
+
+            return new AndConstraint<TaskAssertions>(this);
+        }
+
+        public AndConstraint<TaskAssertions> BeCompletedWithSuccess(string because = "", params object[] reasonArgs)
+        {
+            // Freeze actual value, since the status of a task may change during execution
+            var actualStatus = Subject.Status;
+
+            Execute.Assertion
+                .ForCondition(actualStatus == TaskStatus.RanToCompletion)
+                .BecauseOf(because, reasonArgs)
+                .FailWith("Expected {context:task} to have completed successfully{reason}, but its actual status was {0:G}.", actualStatus);
+
+            return new AndConstraint<TaskAssertions>(this);
+        }
+
+        public AndConstraint<TaskAssertions> BeCancelled(string because = "", params object[] reasonArgs)
+        {
+            // Freeze actual value, since the status of a task may change during execution
+            var actualStatus = Subject.Status;
+
+            Execute.Assertion
+                .ForCondition(actualStatus == TaskStatus.Canceled)
+                .BecauseOf(because, reasonArgs)
+                .FailWith("Expected {context:task} to be canceled{reason}, but its actual status was {0:G}.", actualStatus);
+
+            return new AndConstraint<TaskAssertions>(this);
+        }
+
+        public AndConstraint<TaskAssertions> BeFaulted(string because = "", params object[] reasonArgs)
+        {
+            return HaveStatus(TaskStatus.Faulted, because, reasonArgs);
+        }
+
+        public AndWhichConstraint<TaskAssertions, Exception> BeFaultedWithException<TException>(string because = "", params object[] reasonArgs)
+        {
+            return BeFaulted(because, reasonArgs).And.HaveException<TException>(because, reasonArgs);
+        }
+
+        public AndConstraint<TaskAssertions> HaveStatus(TaskStatus expectedStatus, string because = "", params object[] reasonArgs)
+        {
+            // Freeze actual value, since the status of a task may change during execution
+            var actualStatus = Subject.Status;
+
+            Execute.Assertion
+                .ForCondition(actualStatus == expectedStatus)
+                .BecauseOf(because, reasonArgs)
+                .FailWith("Expected {context:task} to have status {0:G}{reason}, but its actual status was {1:G}.", expectedStatus, actualStatus);
+
+            return new AndConstraint<TaskAssertions>(this);
+        }
+
+        public AndWhichConstraint<TaskAssertions, Exception> HaveException<TException>(string because = "", params object[] reasonArgs)
+        {
+            // Freeze actual value, since the exception can be set during execution (we don't know if the task is running or completed)
+            var actualException = Subject.Exception;
+
+            Execute.Assertion
+                .ForCondition(actualException is TException)
+                .BecauseOf(because, reasonArgs)
+                .FailWith("Expected {context:task} to have exception {0}{reason}, but found {1}.", typeof(TException), actualException);
+
+            return new AndWhichConstraint<TaskAssertions, Exception>(this, actualException);
+        }
+    }
+}

--- a/FluentAssertionsEx/Extensions/FluentAssertionsExtensions.cs
+++ b/FluentAssertionsEx/Extensions/FluentAssertionsExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using HivePeople.FluentAssertionsEx.Assertions;
+
+namespace HivePeople.FluentAssertionsEx.Extensions
+{
+    public static class FluentAssertionsExtensions
+    {
+        public static CancellationTokenAssertions Should(this CancellationToken actualValue)
+        {
+            return new CancellationTokenAssertions(actualValue);
+        }
+
+        public static TaskAssertions Should(this Task actualValue)
+        {
+            return new TaskAssertions(actualValue);
+        }
+    }
+}

--- a/FluentAssertionsEx/FluentAssertionsEx.csproj
+++ b/FluentAssertionsEx/FluentAssertionsEx.csproj
@@ -52,12 +52,16 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Assertions\CancellationTokenAssertions.cs" />
+    <Compile Include="Assertions\TaskAssertions.cs" />
+    <Compile Include="Extensions\FluentAssertionsExtensions.cs" />
     <Compile Include="Fluent.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
- refactor: pull out extra assertions from the NSubstitute bridge class
  Fluent into new classes
- refactor: rename AssertionMatcher -> FluentAssertionMatcher to
  clearly state what it is - a (argument) matcher for
  FluentAssertions-style asserts
