### PR TITLE
[TSS-52] Add ability to verify call order

### DIFF
--- a/FluentAssertionsEx.UnitTest/FluentAssertionsEx.UnitTest.csproj
+++ b/FluentAssertionsEx.UnitTest/FluentAssertionsEx.UnitTest.csproj
@@ -1,0 +1,122 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A32C1A45-3859-46BC-9BCD-296E2444978D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FluentAssertionsEx.UnitTest</RootNamespace>
+    <AssemblyName>FluentAssertionsEx.UnitTest</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FluentAssertions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NSubstitute, Version=1.9.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.1.9.2.0\lib\net45\NSubstitute.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.core.interfaces, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.util, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="NUnit.VisualStudio.TestAdapter, Version=2.0.0.0, Culture=neutral, PublicKeyToken=4cb40d35494691ac, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise />
+  </Choose>
+  <ItemGroup>
+    <Compile Include="NSubstitute\FluentTest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\FluentAssertionsEx\FluentAssertionsEx.csproj">
+      <Project>{a9503da8-9f87-477d-b1cf-f2c75fe23f75}</Project>
+      <Name>FluentAssertionsEx</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/FluentAssertionsEx.UnitTest/NSubstitute/FluentTest.cs
+++ b/FluentAssertionsEx.UnitTest/NSubstitute/FluentTest.cs
@@ -47,7 +47,7 @@ namespace FluentAssertionsEx.UnitTest.NSubstitute
                 mock.CompareTo(yetAnotherObj);
             });
 
-            outOfOrder.ShouldThrow<Exception>();
+            outOfOrder.ShouldThrow<CallSequenceNotFoundException>();
         }
 
         [Test]

--- a/FluentAssertionsEx.UnitTest/NSubstitute/FluentTest.cs
+++ b/FluentAssertionsEx.UnitTest/NSubstitute/FluentTest.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using HivePeople.FluentAssertionsEx;
+using NSubstitute;
+using FluentAssertions;
+using NUnit.Framework;
+using NSubstitute.Exceptions;
+
+namespace FluentAssertionsEx.UnitTest.NSubstitute
+{
+    [TestFixture]
+    public class FluentTest
+    {
+        [Test]
+        public void ReceivedInOrderAcceptsCallsMadeInOrder()
+        {
+            Fluent.Init();
+
+            var mock = Substitute.For<IComparable>();
+            var otherObj = new Object();
+            var yetAnotherObj = new Object();
+
+            mock.CompareTo(otherObj);
+            mock.CompareTo(yetAnotherObj);
+
+            Fluent.ReceivedInOrder(() =>
+            {
+                mock.CompareTo(otherObj);
+                mock.CompareTo(yetAnotherObj);
+            });
+        }
+
+        [Test]
+        public void ReceivedInOrderRejectsCallsMadeOutOfOrder()
+        {
+            Fluent.Init();
+
+            var mock = Substitute.For<IComparable>();
+            var otherObj = new Object();
+            var yetAnotherObj = new Object();
+
+            mock.CompareTo(yetAnotherObj);
+            mock.CompareTo(otherObj);
+
+            Action outOfOrder = () => Fluent.ReceivedInOrder(() =>
+            {
+                mock.CompareTo(otherObj);
+                mock.CompareTo(yetAnotherObj);
+            });
+
+            outOfOrder.ShouldThrow<Exception>();
+        }
+
+        [Test]
+        public void ReceivedInOrderAcceptsCallsMadeInOrderWithFluentSpec()
+        {
+            Fluent.Init();
+
+            var mock = Substitute.For<IComparable<string>>();
+
+            mock.CompareTo("a");
+            mock.CompareTo("b");
+
+            Fluent.ReceivedInOrder(() =>
+            {
+                mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("a")));
+                mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("b")));
+            });
+        }
+
+        [Test]
+        public void ReceivedInOrderRejectsCallsMadeOutOfOrderWithFluentSpec()
+        {
+            Fluent.Init();
+
+            var mock = Substitute.For<IComparable<string>>();
+
+            mock.CompareTo("b");
+            mock.CompareTo("a");
+
+            Action callingReceivedInOrder = () => Fluent.ReceivedInOrder(() =>
+            {
+                mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("a")));
+                mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("b")));
+            });
+
+            callingReceivedInOrder.ShouldThrow<CallSequenceNotFoundException>();
+        }
+    }
+}

--- a/FluentAssertionsEx.UnitTest/Properties/AssemblyInfo.cs
+++ b/FluentAssertionsEx.UnitTest/Properties/AssemblyInfo.cs
@@ -4,8 +4,8 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("FluentAssertionsEx")]
-[assembly: AssemblyDescription("Extensions for FluentAssertions")]
+[assembly: AssemblyTitle("FluentAssertionsEx.UnitTest")]
+[assembly: AssemblyDescription("Extensions for FluentAssertions - Unit Tests")]
 [assembly: AssemblyCompany("HivePeople ApS")]
 [assembly: AssemblyProduct("FluentAssertionsEx")]
 [assembly: AssemblyCopyright("Copyright © HivePeople 2016")]

--- a/FluentAssertionsEx.UnitTest/packages.config
+++ b/FluentAssertionsEx.UnitTest/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FluentAssertions" version="4.2.1" targetFramework="net46" />
+  <package id="NSubstitute" version="1.9.2.0" targetFramework="net46" />
+  <package id="NUnit" version="2.6.4" targetFramework="net46" />
+  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net46" />
+</packages>

--- a/FluentAssertionsEx.sln
+++ b/FluentAssertionsEx.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentAssertionsEx", "FluentAssertionsEx\FluentAssertionsEx.csproj", "{A9503DA8-9F87-477D-B1CF-F2C75FE23F75}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentAssertionsEx.UnitTest", "FluentAssertionsEx.UnitTest\FluentAssertionsEx.UnitTest.csproj", "{A32C1A45-3859-46BC-9BCD-296E2444978D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{A9503DA8-9F87-477D-B1CF-F2C75FE23F75}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A9503DA8-9F87-477D-B1CF-F2C75FE23F75}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A9503DA8-9F87-477D-B1CF-F2C75FE23F75}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A32C1A45-3859-46BC-9BCD-296E2444978D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A32C1A45-3859-46BC-9BCD-296E2444978D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A32C1A45-3859-46BC-9BCD-296E2444978D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A32C1A45-3859-46BC-9BCD-296E2444978D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FluentAssertionsEx/Fluent.cs
+++ b/FluentAssertionsEx/Fluent.cs
@@ -1,21 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
-using FluentAssertions;
+using System.Threading;
 using FluentAssertions.Common;
-using NSubstitute;
+using HivePeople.FluentAssertionsEx.NSubstitute.Query;
 using NSubstitute.Core;
 using NSubstitute.Core.Arguments;
-using NSubstitute.Core.SequenceChecking;
-using NSubstitute.Exceptions;
 
 namespace HivePeople.FluentAssertionsEx
 {
-    // NSubstitute.Core contains a duplicate definition of the Enumerable.Zip extension method, which would normally
-    // cause compile errors, since the compiler cannot decide which one to use. But if we move one using declaration
-    // to an inner namespace, we effectively prioritize extension methods from that using declarations namespace.
-    // See: http://codeblog.jonskeet.uk/2010/11/03/using-extension-method-resolution-rules-to-decorate-awaiters/
-    using System.Linq;
-
     /// <summary>
     /// Bridges the gap between NSubstitute and Fluent Assertions. Inspired by a blog post by Rory Primrose, but this
     /// version circumvents the NSubstitute exception catching machinery to directly throw exceptions from FA, so you
@@ -84,7 +75,7 @@ namespace HivePeople.FluentAssertionsEx
                 }
                 catch (Exception e)
                 {
-                    if (fluentExceptionType.Value.IsInstanceOfType(e))
+                    if (FluentExceptionType.Value.IsInstanceOfType(e))
                     {
                         // We explicitly let exceptions from Fluent Assertions escape
                         throw e;
@@ -103,66 +94,9 @@ namespace HivePeople.FluentAssertionsEx
             }
         }
 
-        // TODO: Figure out how to hook this up to NSubstitute, to enable call order verification with fluent assertions
-        private class FluentQuery
-        {
-            private readonly List<CallSpecAndTarget> querySpec = new List<CallSpecAndTarget>();
-
-            public void Add(ICallSpecification callSpecification, object target)
-            {
-                querySpec.Add(new CallSpecAndTarget(callSpecification, target));
-            }
-
-            public void VerifyExactCallOrder()
-            {
-                List<ICall> calls = new List<ICall>();
-                foreach (var csat in querySpec)
-                    calls.AddRange(csat.Target.ReceivedCalls());
-
-                var callOrderChecks = calls.OrderBy(call => call.GetSequenceNumber()).Zip(querySpec.AsEnumerable(), (call, spec) =>
-                {
-                    return ReferenceEquals(call.Target(), spec.Target) && spec.CallSpecification.IsSatisfiedBy(call);
-                });
-
-                try
-                {
-                    if (callOrderChecks.Any(match => !match))
-                        throw new CallSequenceNotFoundException(GetCallOrderExceptionMessage(querySpec, calls, ""));
-                }
-                catch (Exception e)
-                {
-                    // Only exceptions thrown by FA should propagate to this point
-                    e.Should().BeOfType(fluentExceptionType.Value);
-
-                    throw new CallSequenceNotFoundException(GetCallOrderExceptionMessage(querySpec, calls, GetFluentErrorMessage(e)));
-                }
-            }
-
-            /// <summary>This method is heavily inspired by NSubstitute.Core.SequenceChecking.SequenceInOrderAssertion.GetExceptionMessage</summary>
-            /// <see cref="https://github.com/nsubstitute/NSubstitute/blob/master/Source/NSubstitute/Core/SequenceChecking/SequenceInOrderAssertion.cs#L62"/>
-            private string GetCallOrderExceptionMessage(IEnumerable<CallSpecAndTarget> querySpec, IEnumerable<ICall> callsInOrder, string fluentError)
-            {
-                const string callDelimiter = "\n    ";
-                var formatter = new SequenceFormatter(callDelimiter, querySpec.ToArray(), callsInOrder.ToArray());
-
-                return String.Format("\nExpected to receive these calls in order:\n{0}{1}\n" +
-                    "\nActually received calls to target instances in this order:\n{0}{2}\n\n{3}{4}",
-                    callDelimiter, formatter.FormatQuery(), formatter.FormatActualCalls(),
-                    "*** Note: calls to property getters are not considered part of the query. ***",
-                    fluentError);
-            }
-
-            private string GetFluentErrorMessage(Exception exception)
-            {
-                return "\n\nFluent Assertions said:\n" + exception.Message;
-            }
-        }
-
-        // NOTE: This is only to emulate behaviour of ArgumentSpecificationQueue, may not be needed
-        private static readonly ISubstitutionContext substitutionContextAtStart = SubstitutionContext.Current;
 
         /// <summary>The type of exception thrown by FA on this platform. Necessary because it varies with platform.</summary>
-        private static Lazy<Type> fluentExceptionType = new Lazy<Type>(() =>
+        internal static Lazy<Type> FluentExceptionType = new Lazy<Type>(() =>
         {
             try
             {
@@ -177,15 +111,38 @@ namespace HivePeople.FluentAssertionsEx
             throw new Exception("Services.ThrowException did not throw an exception!");
         });
 
+        public static void Init()
+        {
+            var activeContext = SubstitutionContext.Current;
+
+            if (activeContext is FluentQuerySubstitutionContext)
+                return;  // Nothing to do
+
+            // TODO: This is not thread-safe since SubstitutionContext.Current is shared global state
+            // See: https://github.com/nsubstitute/NSubstitute/issues/220
+            // Until resolved, tests that use Fluent.Init are not parallelizable with other tests using NSubstitute
+            SubstitutionContext.Current = new FluentQuerySubstitutionContext(activeContext);
+        }
+
         public static T Match<T>(Action<T> action)
         {
             var matcher = new FluentAssertionMatcher<T>(action);
             var innerArgumentSpecification = new ArgumentSpecification(typeof(T), matcher);
             var fluentArgumentSpecification = new FluentArgumentSpecification(innerArgumentSpecification, matcher);
 
-            substitutionContextAtStart.EnqueueArgumentSpecification(fluentArgumentSpecification);
+            SubstitutionContext.Current.EnqueueArgumentSpecification(fluentArgumentSpecification);
 
             return default(T);
+        }
+
+        public static void ReceivedInOrder(Action calls)
+        {
+            var fluentContext = SubstitutionContext.Current as FluentQuerySubstitutionContext;
+            if (fluentContext == null)
+                throw new InvalidOperationException("Must call Fluent.Init() before creating mocks when using Fluent.ReceivedInOrder");
+
+            var query = fluentContext.RunFluentQuery(calls);
+            query.VerifyExactCallOrder();
         }
     }
 }

--- a/FluentAssertionsEx/FluentAssertionsEx.csproj
+++ b/FluentAssertionsEx/FluentAssertionsEx.csproj
@@ -57,6 +57,8 @@
     <Compile Include="Extensions\FluentAssertionsExtensions.cs" />
     <Compile Include="Fluent.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="NSubstitute\Query\FluentQuery.cs" />
+    <Compile Include="NSubstitute\Query\FluentQuerySubstitutionContext.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/FluentAssertionsEx/NSubstitute/Query/FluentQuery.cs
+++ b/FluentAssertionsEx/NSubstitute/Query/FluentQuery.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using FluentAssertions;
+using NSubstitute;
+using NSubstitute.Core;
+using NSubstitute.Core.SequenceChecking;
+using NSubstitute.Exceptions;
+
+
+namespace HivePeople.FluentAssertionsEx.NSubstitute.Query
+{
+    // NSubstitute.Core contains a duplicate definition of the Enumerable.Zip extension method, which would normally
+    // cause compile errors, since the compiler cannot decide which one to use. But if we move one using declaration
+    // to an inner namespace, we effectively prioritize extension methods from that using declarations namespace.
+    // See: http://codeblog.jonskeet.uk/2010/11/03/using-extension-method-resolution-rules-to-decorate-awaiters/
+    using System.Linq;
+
+    // TODO: Figure out how to hook this up to NSubstitute, to enable call order verification with fluent assertions
+    public class FluentQuery
+    {
+        class ReferenceEqualityComparer : IEqualityComparer<object>
+        {
+            public new bool Equals(object x, object y)
+            {
+                return Object.ReferenceEquals(x, y);
+            }
+
+            public int GetHashCode(object obj)
+            {
+                return RuntimeHelpers.GetHashCode(obj);
+            }
+        }
+
+        private readonly List<CallSpecAndTarget> querySpec = new List<CallSpecAndTarget>();
+
+        public void Add(ICallSpecification callSpecification, object target)
+        {
+            querySpec.Add(new CallSpecAndTarget(callSpecification, target));
+        }
+
+        public void VerifyExactCallOrder()
+        {
+            var callsInOrder = querySpec
+                .Select(csat => csat.Target)
+                .Distinct(new ReferenceEqualityComparer())
+                .SelectMany(tgt => tgt.ReceivedCalls())
+                .OrderBy(call => call.GetSequenceNumber());
+            
+            var callOrderChecks = callsInOrder.Zip(querySpec, (call, spec) =>
+            {
+                return ReferenceEquals(call.Target(), spec.Target) && spec.CallSpecification.IsSatisfiedBy(call);
+            });
+
+            try
+            {
+                if (callOrderChecks.Any(match => !match))
+                    throw new CallSequenceNotFoundException(GetCallOrderExceptionMessage(querySpec, callsInOrder, ""));
+            }
+            catch (CallSequenceNotFoundException)
+            {
+                // Not the exception we are looking for, rethrow
+                throw;
+            }
+            catch (Exception e)
+            {
+                // Only exceptions thrown by FA should propagate to this point
+                e.Should().BeOfType(Fluent.FluentExceptionType.Value);
+
+                throw new CallSequenceNotFoundException(GetCallOrderExceptionMessage(querySpec, callsInOrder, GetFluentErrorMessage(e)));
+            }
+        }
+
+        /// <summary>This method is heavily inspired by NSubstitute.Core.SequenceChecking.SequenceInOrderAssertion.GetExceptionMessage</summary>
+        /// <see cref="https://github.com/nsubstitute/NSubstitute/blob/master/Source/NSubstitute/Core/SequenceChecking/SequenceInOrderAssertion.cs#L62"/>
+        private string GetCallOrderExceptionMessage(IEnumerable<CallSpecAndTarget> querySpec, IEnumerable<ICall> callsInOrder, string fluentError)
+        {
+            const string callDelimiter = "\n    ";
+            var formatter = new SequenceFormatter(callDelimiter, querySpec.ToArray(), callsInOrder.ToArray());
+
+            return String.Format("\nExpected to receive these calls in order:\n{0}{1}\n" +
+                "\nActually received calls to target instances in this order:\n{0}{2}\n\n{3}{4}",
+                callDelimiter, formatter.FormatQuery(), formatter.FormatActualCalls(),
+                "*** Note: calls to property getters are not considered part of the query. ***",
+                fluentError);
+        }
+
+        private string GetFluentErrorMessage(Exception exception)
+        {
+            return "\n\nFluent Assertions said:\n" + exception.Message;
+        }
+    }
+}

--- a/FluentAssertionsEx/NSubstitute/Query/FluentQuery.cs
+++ b/FluentAssertionsEx/NSubstitute/Query/FluentQuery.cs
@@ -16,7 +16,6 @@ namespace HivePeople.FluentAssertionsEx.NSubstitute.Query
     // See: http://codeblog.jonskeet.uk/2010/11/03/using-extension-method-resolution-rules-to-decorate-awaiters/
     using System.Linq;
 
-    // TODO: Figure out how to hook this up to NSubstitute, to enable call order verification with fluent assertions
     public class FluentQuery
     {
         class ReferenceEqualityComparer : IEqualityComparer<object>

--- a/FluentAssertionsEx/NSubstitute/Query/FluentQuerySubstitutionContext.cs
+++ b/FluentAssertionsEx/NSubstitute/Query/FluentQuerySubstitutionContext.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using NSubstitute.Core;
+using NSubstitute.Core.Arguments;
+using NSubstitute.Exceptions;
+using NSubstitute.Proxies;
+using NSubstitute.Proxies.CastleDynamicProxy;
+using NSubstitute.Proxies.DelegateProxy;
+using NSubstitute.Routing;
+
+namespace HivePeople.FluentAssertionsEx.NSubstitute.Query
+{
+    public class FluentQuerySubstitutionContext : ISubstitutionContext
+    {
+        private readonly ISubstitutionContext innerContext;
+        private readonly ISubstituteFactory substituteFactory;
+        private readonly AsyncLocal<FluentQuery> query = new AsyncLocal<FluentQuery>();
+
+        public FluentQuerySubstitutionContext(ISubstitutionContext innerContext)
+        {
+            this.innerContext = innerContext;
+
+            var callRouterFactory = new CallRouterFactory();
+            var dynamicProxyFactory = new CastleDynamicProxyFactory();
+            var delegateFactory = new DelegateProxyFactory();
+            var proxyFactory = new ProxyFactory(delegateFactory, dynamicProxyFactory);
+            var callRouteResolver = new CallRouterResolver();
+
+            this.substituteFactory = new SubstituteFactory(this, callRouterFactory, proxyFactory, callRouteResolver);
+        }
+
+        // CODESTD: This class groups members by implementation strategy (delegating vs specializing)
+
+        #region Delegated members
+        public SequenceNumberGenerator SequenceNumberGenerator { get { return innerContext.SequenceNumberGenerator; } }
+
+        public void ClearLastCallRouter()
+        {
+            innerContext.ClearLastCallRouter();
+        }
+
+        public IList<IArgumentSpecification> DequeueAllArgumentSpecifications()
+        {
+            return innerContext.DequeueAllArgumentSpecifications();
+        }
+
+        public void EnqueueArgumentSpecification(IArgumentSpecification spec)
+        {
+            innerContext.EnqueueArgumentSpecification(spec);
+        }
+
+        public ICallRouter GetCallRouterFor(object substitute)
+        {
+            return innerContext.GetCallRouterFor(substitute);
+        }
+
+        public IRouteFactory GetRouteFactory()
+        {
+            return innerContext.GetRouteFactory();
+        }
+
+        public void LastCallRouter(ICallRouter callRouter)
+        {
+            innerContext.LastCallRouter(callRouter);
+        }
+
+        public ConfiguredCall LastCallShouldReturn(IReturn value, MatchArgs matchArgs)
+        {
+            return innerContext.LastCallShouldReturn(value, matchArgs);
+        }
+
+        public void RaiseEventForNextCall(Func<ICall, object[]> getArguments)
+        {
+            innerContext.RaiseEventForNextCall(getArguments);
+        }
+        #endregion Delegated members
+
+        #region Specialized members
+        public bool IsQuerying { get { return query.Value != null; } }
+
+        public ISubstituteFactory SubstituteFactory { get { return substituteFactory; } }
+
+        public IQueryResults RunQuery(Action calls)
+        {
+            // Cannot retrofit RunQuery since IQueryResults interface doesn't make sense for FluentQuery
+            throw new NotImplementedException();
+        }
+
+        public FluentQuery RunFluentQuery(Action calls)
+        {
+            if (IsQuerying)
+                throw new InvalidOperationException("Cannot run nested queries");
+
+            var activeQuery = new FluentQuery();
+            query.Value = activeQuery;
+            try
+            {
+                calls();
+            }
+            finally
+            {
+                query.Value = null;
+            }
+
+            return activeQuery;
+        }
+
+        public void AddToQuery(object target, ICallSpecification callSpecification)
+        {
+            if (!IsQuerying)
+                throw new NotRunningAQueryException();
+
+            query.Value.Add(callSpecification, target);
+        }
+        #endregion Specialized members
+    }
+}


### PR DESCRIPTION
- refactor: extract FluentQuery from Fluent.cs
- add: ability to verify call sequence whilst using fluent argument
  matching
- add: minor testing of the new feature
