### PR TITLE
[TSS-52] Added async support for queries

### DIFF
--- a/FluentAssertionsEx/Fluent.cs
+++ b/FluentAssertionsEx/Fluent.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions.Common;
 using HivePeople.FluentAssertionsEx.NSubstitute.Query;
 using NSubstitute.Core;
@@ -142,6 +143,16 @@ namespace HivePeople.FluentAssertionsEx
                 throw new InvalidOperationException("Must call Fluent.Init() before creating mocks when using Fluent.ReceivedInOrder");
 
             var query = fluentContext.RunFluentQuery(calls);
+            query.VerifyExactCallOrder();
+        }
+
+        public static async Task ReceivedInOrder(Func<Task> asyncCalls)
+        {
+            var fluentContext = SubstitutionContext.Current as FluentQuerySubstitutionContext;
+            if (fluentContext == null)
+                throw new InvalidOperationException("Must call Fluent.Init() before creating mocks when using Fluent.ReceivedInOrder");
+
+            var query = await fluentContext.RunFluentQueryAsync(asyncCalls);
             query.VerifyExactCallOrder();
         }
     }

--- a/FluentAssertionsEx/NSubstitute/Query/FluentQuerySubstitutionContext.cs
+++ b/FluentAssertionsEx/NSubstitute/Query/FluentQuerySubstitutionContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using NSubstitute.Core;
 using NSubstitute.Core.Arguments;
 using NSubstitute.Exceptions;
@@ -8,20 +9,46 @@ using NSubstitute.Proxies;
 using NSubstitute.Proxies.CastleDynamicProxy;
 using NSubstitute.Proxies.DelegateProxy;
 using NSubstitute.Routing;
+using NSubstitute.Routing.Handlers;
 
 namespace HivePeople.FluentAssertionsEx.NSubstitute.Query
 {
     public class FluentQuerySubstitutionContext : ISubstitutionContext
     {
+        private class FluentQueryCompatibleRouteFactory : RouteFactory, IRouteFactory
+        {
+            IRoute IRouteFactory.CallQuery(ISubstituteState state)
+            {
+                return new Route(new ICallHandler[]
+                {
+                    new ClearUnusedCallSpecHandler(state),
+                    new AddCallToQueryResultHandler(state.SubstitutionContext, state.CallSpecificationFactory),
+                    // new ReturnConfiguredResultHandler(state.CallResults),  <- handler incompatible with FluentArgumentSpecification
+                    new ReturnAutoValue(AutoValueBehaviour.UseValueForSubsequentCalls, state.AutoValueProviders, state.ConfigureCall),
+                    new ReturnDefaultForReturnTypeHandler(new DefaultForType())
+                });
+            }
+        }
+
+        private class FluentCallRouterFactory : ICallRouterFactory
+        {
+            public ICallRouter Create(ISubstitutionContext substitutionContext, SubstituteConfig config)
+            {
+                var state = new SubstituteState(substitutionContext, config);
+                return new CallRouter(state, substitutionContext, new FluentQueryCompatibleRouteFactory());
+            }
+        }
+
+        private static readonly AsyncLocal<FluentQuery> query = new AsyncLocal<FluentQuery>();
+
         private readonly ISubstitutionContext innerContext;
         private readonly ISubstituteFactory substituteFactory;
-        private readonly AsyncLocal<FluentQuery> query = new AsyncLocal<FluentQuery>();
 
         public FluentQuerySubstitutionContext(ISubstitutionContext innerContext)
         {
             this.innerContext = innerContext;
 
-            var callRouterFactory = new CallRouterFactory();
+            var callRouterFactory = new FluentCallRouterFactory();
             var dynamicProxyFactory = new CastleDynamicProxyFactory();
             var delegateFactory = new DelegateProxyFactory();
             var proxyFactory = new ProxyFactory(delegateFactory, dynamicProxyFactory);
@@ -81,13 +108,32 @@ namespace HivePeople.FluentAssertionsEx.NSubstitute.Query
 
         public ISubstituteFactory SubstituteFactory { get { return substituteFactory; } }
 
+        public void AddToQuery(object target, ICallSpecification callSpecification)
+        {
+            if (!IsQuerying)
+                throw new NotRunningAQueryException();
+
+            query.Value.Add(callSpecification, target);
+        }
+
         public IQueryResults RunQuery(Action calls)
         {
             // Cannot retrofit RunQuery since IQueryResults interface doesn't make sense for FluentQuery
             throw new NotImplementedException();
         }
+        #endregion Specialized members
 
+        #region New members
         public FluentQuery RunFluentQuery(Action calls)
+        {
+            return RunFluentQueryAsync(() =>
+            {
+                calls();
+                return Task.CompletedTask;
+            }).Result;
+        }
+
+        public async Task<FluentQuery> RunFluentQueryAsync(Func<Task> calls)
         {
             if (IsQuerying)
                 throw new InvalidOperationException("Cannot run nested queries");
@@ -96,7 +142,7 @@ namespace HivePeople.FluentAssertionsEx.NSubstitute.Query
             query.Value = activeQuery;
             try
             {
-                calls();
+                await calls();
             }
             finally
             {
@@ -105,14 +151,6 @@ namespace HivePeople.FluentAssertionsEx.NSubstitute.Query
 
             return activeQuery;
         }
-
-        public void AddToQuery(object target, ICallSpecification callSpecification)
-        {
-            if (!IsQuerying)
-                throw new NotRunningAQueryException();
-
-            query.Value.Add(callSpecification, target);
-        }
-        #endregion Specialized members
+        #endregion New members
     }
 }

--- a/FluentAssertionsEx/Properties/AssemblyInfo.cs
+++ b/FluentAssertionsEx/Properties/AssemblyInfo.cs
@@ -25,8 +25,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0.2")]
+[assembly: AssemblyVersion("0.1.0.3")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-alpha2")]
+[assembly: AssemblyInformationalVersion("1.0.0-alpha3")]


### PR DESCRIPTION
- add: async version of ReceivedInOrder, for use when verifying call
  order for async methods
- fix: the default route factory would sometimes generate calls to
  FluentArgumentSpecification.IsSatisfiedBy during querying - not
  allowable when the method can throw
