### PR TITLE
[TSS-52] fluent query - verify fluent calls in any order

### DIFF
--- a/FluentAssertionsEx.UnitTest/NSubstitute/FluentTest.cs
+++ b/FluentAssertionsEx.UnitTest/NSubstitute/FluentTest.cs
@@ -135,5 +135,98 @@ namespace FluentAssertionsEx.UnitTest.NSubstitute
 
             callingReceivedInOrder.ShouldThrow<CallSequenceNotFoundException>();
         }
+
+        [Test]
+        public void ReceivedInAnyOrderAcceptsCallsMadeInOrder()
+        {
+            Fluent.Init();
+
+            var mock = Substitute.For<IComparable>();
+            var otherObj = new Object();
+            var yetAnotherObj = new Object();
+
+            mock.CompareTo(otherObj);
+            mock.CompareTo(yetAnotherObj);
+
+            Fluent.ReceivedInAnyOrder(() =>
+            {
+                mock.CompareTo(otherObj);
+                mock.CompareTo(yetAnotherObj);
+            });
+        }
+
+        [Test]
+        public void ReceivedInAnyOrderAcceptsCallsMadeOutOfOrder()
+        {
+            Fluent.Init();
+
+            var mock = Substitute.For<IComparable>();
+            var otherObj = new Object();
+            var yetAnotherObj = new Object();
+
+            mock.CompareTo(yetAnotherObj);
+            mock.CompareTo(otherObj);
+
+            Fluent.ReceivedInAnyOrder(() =>
+            {
+                mock.CompareTo(otherObj);
+                mock.CompareTo(yetAnotherObj);
+            });
+        }
+
+        [Test]
+        public void ReceivedInAnyOrderRejectsMissingCall()
+        {
+            Fluent.Init();
+
+            var mock = Substitute.For<IComparable>();
+            var otherObj = new Object();
+            var yetAnotherObj = new Object();
+
+            mock.CompareTo(otherObj);
+
+            Action callingReceivedInAnyOrder = () => Fluent.ReceivedInAnyOrder(() =>
+            {
+                mock.CompareTo(otherObj);
+                mock.CompareTo(yetAnotherObj);
+            });
+
+            callingReceivedInAnyOrder.ShouldThrow<CallSequenceNotFoundException>();
+        }
+
+        [Test]
+        public void ReceivedInAnyOrderAcceptsCallsWithFluentSpec()
+        {
+            Fluent.Init();
+
+            var mock = Substitute.For<IComparable<string>>();
+
+            mock.CompareTo("b");
+            mock.CompareTo("a");
+
+            Fluent.ReceivedInAnyOrder(() =>
+            {
+                mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("a")));
+                mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("b")));
+            });
+        }
+
+        [Test]
+        public void ReceivedInAnyOrderRejectsMissingCallWithFluentSpec()
+        {
+            Fluent.Init();
+
+            var mock = Substitute.For<IComparable<string>>();
+
+            mock.CompareTo("b");
+
+            Action callingReceivedInAnyOrder = () => Fluent.ReceivedInAnyOrder(() =>
+            {
+                mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("a")));
+                mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("b")));
+            });
+
+            callingReceivedInAnyOrder.ShouldThrow<CallSequenceNotFoundException>();
+        }
     }
 }

--- a/FluentAssertionsEx/Fluent.cs
+++ b/FluentAssertionsEx/Fluent.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
@@ -179,6 +178,16 @@ namespace HivePeople.FluentAssertionsEx
                 throw new InvalidOperationException("Must call Fluent.Init() before creating mocks when using Fluent.ReceivedInAnyOrder");
 
             var query = fluentContext.RunFluentQuery(calls);
+            query.VerifyAnyCallOrder();
+        }
+
+        public static async Task ReceivedInAnyOrder(Func<Task> asyncCalls)
+        {
+            var fluentContext = SubstitutionContext.Current as FluentQuerySubstitutionContext;
+            if (fluentContext == null)
+                throw new InvalidOperationException("Must call Fluent.Init() before creating mocks when using Fluent.ReceivedInAnyOrder");
+
+            var query = await fluentContext.RunFluentQueryAsync(asyncCalls);
             query.VerifyAnyCallOrder();
         }
     }

--- a/FluentAssertionsEx/Fluent.cs
+++ b/FluentAssertionsEx/Fluent.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions.Common;
+using FluentAssertions.Execution;
 using HivePeople.FluentAssertionsEx.NSubstitute.Query;
 using NSubstitute.Core;
 using NSubstitute.Core.Arguments;
@@ -27,8 +28,23 @@ namespace HivePeople.FluentAssertionsEx
 
             public bool IsSatisfiedBy(object argument)
             {
+                bool success = false;
+
+                // This is stupid: because AssertionScope provides no ability to peek inside and because we need to
+                // preserve any failures if we are querying, we must perform the assertion twice
+
+                // First we determine if the assertion succeeds without triggering exceptions
+                using (var assertScope = new AssertionScope())
+                {
+                    assertion((T)argument);
+                    var failures = assertScope.Discard();
+                    success = failures.Length == 0;
+                }
+
+                // Then we rerun it to either throw an exception or report error to an enclosing scope
                 assertion((T)argument);
-                return true;
+
+                return success;
             }
         }
 
@@ -154,6 +170,16 @@ namespace HivePeople.FluentAssertionsEx
 
             var query = await fluentContext.RunFluentQueryAsync(asyncCalls);
             query.VerifyExactCallOrder();
+        }
+
+        public static void ReceivedInAnyOrder(Action calls)
+        {
+            var fluentContext = SubstitutionContext.Current as FluentQuerySubstitutionContext;
+            if (fluentContext == null)
+                throw new InvalidOperationException("Must call Fluent.Init() before creating mocks when using Fluent.ReceivedInAnyOrder");
+
+            var query = fluentContext.RunFluentQuery(calls);
+            query.VerifyAnyCallOrder();
         }
     }
 }

--- a/FluentAssertionsEx/NSubstitute/Query/FluentQuery.cs
+++ b/FluentAssertionsEx/NSubstitute/Query/FluentQuery.cs
@@ -15,6 +15,7 @@ namespace HivePeople.FluentAssertionsEx.NSubstitute.Query
     // to an inner namespace, we effectively prioritize extension methods from that using declarations namespace.
     // See: http://codeblog.jonskeet.uk/2010/11/03/using-extension-method-resolution-rules-to-decorate-awaiters/
     using System.Linq;
+    using FluentAssertions.Execution;
 
     public class FluentQuery
     {
@@ -63,10 +64,41 @@ namespace HivePeople.FluentAssertionsEx.NSubstitute.Query
             }
             catch (Exception e)
             {
+                // TODO: Can this be cleaned up via AssertionScope?
                 // Only exceptions thrown by FA should propagate to this point
                 e.Should().BeOfType(Fluent.FluentExceptionType.Value);
 
                 throw new CallSequenceNotFoundException(GetCallOrderExceptionMessage(querySpec, callsInOrder, GetFluentErrorMessage(e)));
+            }
+        }
+
+        public void VerifyAnyCallOrder()
+        {
+            foreach (var grp in querySpec.GroupBy(csat => csat.Target, new ReferenceEqualityComparer()))
+            {
+                var remainingCallsOnTarget = grp.Key.ReceivedCalls().ToList();
+
+                foreach (var csat in grp)
+                {
+                    using (var assertScope = new AssertionScope())
+                    {
+                        var indexOfMatch = remainingCallsOnTarget.FindIndex(csat.CallSpecification.IsSatisfiedBy);
+
+                        if (indexOfMatch >= 0)
+                        {
+                            // Consume match
+                            remainingCallsOnTarget.RemoveAt(indexOfMatch);
+                            assertScope.Discard();  // discard failures from non-matches
+                        }
+                        else
+                        {
+                            var failures = assertScope.Discard();
+                            var fluentError = (failures.Length == 0) ? "" : "\n\nFluent Assertions said:\n" + String.Join("\n", failures);
+                            var msg = GetMissingCallExceptionMessage(querySpec, csat.CallSpecification, csat.Target.ReceivedCalls(), fluentError);
+                            throw new CallSequenceNotFoundException(msg);
+                        }
+                    }
+                }
             }
         }
 
@@ -80,6 +112,21 @@ namespace HivePeople.FluentAssertionsEx.NSubstitute.Query
             return String.Format("\nExpected to receive these calls in order:\n{0}{1}\n" +
                 "\nActually received calls to target instances in this order:\n{0}{2}\n\n{3}{4}",
                 callDelimiter, formatter.FormatQuery(), formatter.FormatActualCalls(),
+                "*** Note: calls to property getters are not considered part of the query. ***",
+                fluentError);
+        }
+
+        private string GetMissingCallExceptionMessage(
+            IEnumerable<CallSpecAndTarget> querySpec, ICallSpecification unmatchedCallSpec,
+            IEnumerable<ICall> nonMatchingCalls, string fluentError)
+        {
+            const string callDelimiter = "\n    ";
+            var formatter = new SequenceFormatter(callDelimiter, querySpec.ToArray(), nonMatchingCalls.ToArray());
+
+            return String.Format("\nExpected to receive these calls in any order:\n{0}{1}\n" +
+                "\nBut did not receive call matching:\n{0}{2}" +
+                "\n\nReceived these unmatched calls on that target:\n{0}{3}\n\n{4}{5}",
+                callDelimiter, formatter.FormatQuery(), unmatchedCallSpec, formatter.FormatActualCalls(),
                 "*** Note: calls to property getters are not considered part of the query. ***",
                 fluentError);
         }

--- a/FluentAssertionsEx/Properties/AssemblyInfo.cs
+++ b/FluentAssertionsEx/Properties/AssemblyInfo.cs
@@ -25,8 +25,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0.4")]
+[assembly: AssemblyVersion("0.1.0.5")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-alpha4")]
+[assembly: AssemblyInformationalVersion("1.0.0-alpha5")]

--- a/FluentAssertionsEx/Properties/AssemblyInfo.cs
+++ b/FluentAssertionsEx/Properties/AssemblyInfo.cs
@@ -25,8 +25,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0.3")]
+[assembly: AssemblyVersion("0.1.0.4")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-alpha3")]
+[assembly: AssemblyInformationalVersion("1.0.0-alpha4")]


### PR DESCRIPTION
- add: ability to verify that a bunch of calls using fluent
  specification were made in any order
- add: ability to verify that a bunch of async calls with fluent
  specifications were made in any order
