### PR TITLE
[TSS-409] Support vanilla queries

### DIFF
--- a/FluentAssertionsEx.UnitTest/NSubstitute/FluentTest.cs
+++ b/FluentAssertionsEx.UnitTest/NSubstitute/FluentTest.cs
@@ -269,5 +269,27 @@ namespace FluentAssertionsEx.UnitTest.NSubstitute
 
             callingReceivedInAnyOrder.ShouldThrow<CallSequenceNotFoundException>();
         }
+
+        /// <summary>
+        /// Since it is not easy to unset a fluent context, it should still support vanilla
+        /// <see cref="Received.InOrder(Action)"/> queries.
+        /// </summary>
+        [Test]
+        public void VanillaQueryingIsStillSupported()
+        {
+            Fluent.Init();
+
+            var mock = Substitute.For<IComparable>();
+            object x = new Object(), y = new Object();
+
+            mock.CompareTo(x);
+            mock.CompareTo(y);
+
+            Received.InOrder(() =>
+            {
+                mock.CompareTo(x);
+                mock.CompareTo(y);
+            });
+        }
     }
 }

--- a/FluentAssertionsEx/NSubstitute/Query/FluentQuerySubstitutionContext.cs
+++ b/FluentAssertionsEx/NSubstitute/Query/FluentQuerySubstitutionContext.cs
@@ -101,10 +101,15 @@ namespace HivePeople.FluentAssertionsEx.NSubstitute.Query
         {
             innerContext.RaiseEventForNextCall(getArguments);
         }
+
+        public IQueryResults RunQuery(Action calls)
+        {
+            return innerContext.RunQuery(calls);
+        }
         #endregion Delegated members
 
         #region Specialized members
-        public bool IsQuerying { get { return query.Value != null; } }
+        public bool IsQuerying { get { return query.Value != null || innerContext.IsQuerying; } }
 
         public ISubstituteFactory SubstituteFactory { get { return substituteFactory; } }
 
@@ -113,13 +118,15 @@ namespace HivePeople.FluentAssertionsEx.NSubstitute.Query
             if (!IsQuerying)
                 throw new NotRunningAQueryException();
 
-            query.Value.Add(callSpecification, target);
-        }
-
-        public IQueryResults RunQuery(Action calls)
-        {
-            // Cannot retrofit RunQuery since IQueryResults interface doesn't make sense for FluentQuery
-            throw new NotImplementedException();
+            if (query.Value == null)
+            {
+                // Must be a legacy query, delegate
+                innerContext.AddToQuery(target, callSpecification);
+            }
+            else
+            {
+                query.Value.Add(callSpecification, target);
+            }
         }
         #endregion Specialized members
 

--- a/FluentAssertionsEx/Properties/AssemblyInfo.cs
+++ b/FluentAssertionsEx/Properties/AssemblyInfo.cs
@@ -25,8 +25,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0.6")]
+[assembly: AssemblyVersion("0.1.0.7")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-alpha6")]
+[assembly: AssemblyInformationalVersion("1.0.0-alpha7")]


### PR DESCRIPTION
- add: support vanilla NSubstitute Received.InOrder queries, since it
  is not currently possible to restore default substition context
