### PR TITLE
[TSS-549] Limit fluent context to scope

### DIFF
--- a/FluentAssertionsEx.UnitTest/FluentAssertionsEx.UnitTest.csproj
+++ b/FluentAssertionsEx.UnitTest/FluentAssertionsEx.UnitTest.csproj
@@ -35,16 +35,16 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.11.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.11.0\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=4.11.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.11.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute, Version=1.9.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\packages\NSubstitute.1.9.2.0\lib\net45\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">

--- a/FluentAssertionsEx.UnitTest/NSubstitute/FluentTest.cs
+++ b/FluentAssertionsEx.UnitTest/NSubstitute/FluentTest.cs
@@ -5,6 +5,9 @@ using FluentAssertions;
 using NUnit.Framework;
 using NSubstitute.Exceptions;
 using System.Threading.Tasks;
+using NSubstitute.Core;
+using HivePeople.FluentAssertionsEx.NSubstitute.Query;
+using HivePeople.FluentAssertionsEx.Extensions;
 
 namespace FluentAssertionsEx.UnitTest.NSubstitute
 {
@@ -12,79 +15,98 @@ namespace FluentAssertionsEx.UnitTest.NSubstitute
     public class FluentTest
     {
         [Test]
+        public void EnterQueryScopeRestoresOldContextOnDispose()
+        {
+            var scope = Fluent.EnterQueryScope();
+
+            // Sanity check
+            SubstitutionContext.Current.Should().BeOfType<FluentQuerySubstitutionContext>("because we have entered query scope");
+
+            scope.Dispose();
+
+            // Verify that the current context is no longer our fluent context
+            // TODO: Cannot use the generic version of NotBeOfType yet due to https://github.com/dennisdoomen/FluentAssertions/issues/443
+            SubstitutionContext.Current.Should().NotBeOfType(typeof(FluentQuerySubstitutionContext));
+        }
+
+        [Test]
         public void ReceivedInOrderAcceptsCallsMadeInOrder()
         {
-            Fluent.Init();
-
-            var mock = Substitute.For<IComparable>();
-            var otherObj = new Object();
-            var yetAnotherObj = new Object();
-
-            mock.CompareTo(otherObj);
-            mock.CompareTo(yetAnotherObj);
-
-            Fluent.ReceivedInOrder(() =>
+            using (Fluent.EnterQueryScope())
             {
+                var mock = Substitute.For<IComparable>();
+                var otherObj = new Object();
+                var yetAnotherObj = new Object();
+
                 mock.CompareTo(otherObj);
                 mock.CompareTo(yetAnotherObj);
-            });
+
+                Fluent.ReceivedInOrder(() =>
+                {
+                    mock.CompareTo(otherObj);
+                    mock.CompareTo(yetAnotherObj);
+                });
+            }
         }
 
         [Test]
         public void ReceivedInOrderRejectsCallsMadeOutOfOrder()
         {
-            Fluent.Init();
-
-            var mock = Substitute.For<IComparable>();
-            var otherObj = new Object();
-            var yetAnotherObj = new Object();
-
-            mock.CompareTo(yetAnotherObj);
-            mock.CompareTo(otherObj);
-
-            Action outOfOrder = () => Fluent.ReceivedInOrder(() =>
+            using (Fluent.EnterQueryScope())
             {
-                mock.CompareTo(otherObj);
-                mock.CompareTo(yetAnotherObj);
-            });
+                var mock = Substitute.For<IComparable>();
+                var otherObj = new Object();
+                var yetAnotherObj = new Object();
 
-            outOfOrder.ShouldThrow<CallSequenceNotFoundException>();
+                mock.CompareTo(yetAnotherObj);
+                mock.CompareTo(otherObj);
+
+                Action outOfOrder = () => Fluent.ReceivedInOrder(() =>
+                {
+                    mock.CompareTo(otherObj);
+                    mock.CompareTo(yetAnotherObj);
+                });
+
+                outOfOrder.ShouldThrow<CallSequenceNotFoundException>();
+            }
         }
 
         [Test]
         public void ReceivedInOrderAcceptsCallsMadeInOrderWithFluentSpec()
         {
-            Fluent.Init();
-
-            var mock = Substitute.For<IComparable<string>>();
-
-            mock.CompareTo("a");
-            mock.CompareTo("b");
-
-            Fluent.ReceivedInOrder(() =>
+            using (Fluent.EnterQueryScope())
             {
-                mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("a")));
-                mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("b")));
-            });
+                var mock = Substitute.For<IComparable<string>>();
+
+                mock.CompareTo("a");
+                mock.CompareTo("b");
+
+                Fluent.ReceivedInOrder(() =>
+                {
+                    mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("a")));
+                    mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("b")));
+                });
+            }
         }
 
         [Test]
         public void ReceivedInOrderRejectsCallsMadeOutOfOrderWithFluentSpec()
         {
-            Fluent.Init();
-
-            var mock = Substitute.For<IComparable<string>>();
-
-            mock.CompareTo("b");
-            mock.CompareTo("a");
-
-            Action callingReceivedInOrder = () => Fluent.ReceivedInOrder(() =>
+            using (Fluent.EnterQueryScope())
             {
-                mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("a")));
-                mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("b")));
-            });
+                var mock = Substitute.For<IComparable<string>>();
 
-            callingReceivedInOrder.ShouldThrow<CallSequenceNotFoundException>();
+                mock.CompareTo("b");
+                mock.CompareTo("a");
+
+                Action callingReceivedInOrder = () => Fluent.ReceivedInOrder(() =>
+                {
+                    mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("a")));
+                    mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("b")));
+                });
+
+                callingReceivedInOrder.ShouldThrow<CallSequenceNotFoundException>();
+            }
         }
 
         // NOTE: This interface is public so NSubstitute can easily create a proxy for it
@@ -97,199 +119,208 @@ namespace FluentAssertionsEx.UnitTest.NSubstitute
         [Test]
         public async Task ReceivedInOrderAcceptsAsyncCallsMadeInOrder()
         {
-            Fluent.Init();
-
-            var mock = Substitute.For<IAsyncInterface>();
-            mock.AnotherMethodAsync().Returns(Task.FromResult(2));
-
-            await mock.SomeMethodAsync("yoyo");
-            await mock.AnotherMethodAsync();
-            await mock.SomeMethodAsync("djir");
-
-            await Fluent.ReceivedInOrder(async () =>
+            using (Fluent.EnterQueryScope())
             {
-                await mock.SomeMethodAsync(Fluent.Match<string>(s => s.Should().Contain("yo")));
+                var mock = Substitute.For<IAsyncInterface>();
+                mock.AnotherMethodAsync().Returns(Task.FromResult(2));
+
+                await mock.SomeMethodAsync("yoyo");
                 await mock.AnotherMethodAsync();
-                await mock.SomeMethodAsync(Fluent.Match<string>(s => s.Should().Contain("djir")));
-            });
+                await mock.SomeMethodAsync("djir");
+
+                await Fluent.ReceivedInOrder(async () =>
+                {
+                    await mock.SomeMethodAsync(Fluent.Match<string>(s => s.Should().Contain("yo")));
+                    await mock.AnotherMethodAsync();
+                    await mock.SomeMethodAsync(Fluent.Match<string>(s => s.Should().Contain("djir")));
+                });
+            }
         }
 
         [Test]
         public async Task ReceivedInOrderRejectsAsyncCallsMadeOutOfOrder()
         {
-            Fluent.Init();
-
-            var mock = Substitute.For<IAsyncInterface>();
-            mock.AnotherMethodAsync().Returns(Task.FromResult(2));
-
-            await mock.SomeMethodAsync("djir");
-            await mock.AnotherMethodAsync();
-            await mock.SomeMethodAsync("yoyo");
-
-            Func<Task> callingReceivedInOrder = () => Fluent.ReceivedInOrder(async () =>
+            using (Fluent.EnterQueryScope())
             {
-                await mock.SomeMethodAsync(Fluent.Match<string>(s => s.Should().Contain("yo")));
-                await mock.AnotherMethodAsync();
-                await mock.SomeMethodAsync(Fluent.Match<string>(s => s.Should().Contain("djir")));
-            });
+                var mock = Substitute.For<IAsyncInterface>();
+                mock.AnotherMethodAsync().Returns(Task.FromResult(2));
 
-            callingReceivedInOrder.ShouldThrow<CallSequenceNotFoundException>();
+                await mock.SomeMethodAsync("djir");
+                await mock.AnotherMethodAsync();
+                await mock.SomeMethodAsync("yoyo");
+
+                Func<Task> callingReceivedInOrder = () => Fluent.ReceivedInOrder(async () =>
+                {
+                    await mock.SomeMethodAsync(Fluent.Match<string>(s => s.Should().Contain("yo")));
+                    await mock.AnotherMethodAsync();
+                    await mock.SomeMethodAsync(Fluent.Match<string>(s => s.Should().Contain("djir")));
+                });
+
+                callingReceivedInOrder.ShouldThrow<CallSequenceNotFoundException>();
+            }
         }
 
         [Test]
         public void ReceivedInAnyOrderAcceptsCallsMadeInOrder()
         {
-            Fluent.Init();
-
-            var mock = Substitute.For<IComparable>();
-            var otherObj = new Object();
-            var yetAnotherObj = new Object();
-
-            mock.CompareTo(otherObj);
-            mock.CompareTo(yetAnotherObj);
-
-            Fluent.ReceivedInAnyOrder(() =>
+            using (Fluent.EnterQueryScope())
             {
+                var mock = Substitute.For<IComparable>();
+                var otherObj = new Object();
+                var yetAnotherObj = new Object();
+
                 mock.CompareTo(otherObj);
                 mock.CompareTo(yetAnotherObj);
-            });
+
+                Fluent.ReceivedInAnyOrder(() =>
+                {
+                    mock.CompareTo(otherObj);
+                    mock.CompareTo(yetAnotherObj);
+                });
+            }
         }
 
         [Test]
         public void ReceivedInAnyOrderAcceptsCallsMadeOutOfOrder()
         {
-            Fluent.Init();
-
-            var mock = Substitute.For<IComparable>();
-            var otherObj = new Object();
-            var yetAnotherObj = new Object();
-
-            mock.CompareTo(yetAnotherObj);
-            mock.CompareTo(otherObj);
-
-            Fluent.ReceivedInAnyOrder(() =>
+            using (Fluent.EnterQueryScope())
             {
-                mock.CompareTo(otherObj);
+                var mock = Substitute.For<IComparable>();
+                var otherObj = new Object();
+                var yetAnotherObj = new Object();
+
                 mock.CompareTo(yetAnotherObj);
-            });
+                mock.CompareTo(otherObj);
+
+                Fluent.ReceivedInAnyOrder(() =>
+                {
+                    mock.CompareTo(otherObj);
+                    mock.CompareTo(yetAnotherObj);
+                });
+            }
         }
 
         [Test]
         public void ReceivedInAnyOrderRejectsMissingCall()
         {
-            Fluent.Init();
-
-            var mock = Substitute.For<IComparable>();
-            var otherObj = new Object();
-            var yetAnotherObj = new Object();
-
-            mock.CompareTo(otherObj);
-
-            Action callingReceivedInAnyOrder = () => Fluent.ReceivedInAnyOrder(() =>
+            using (Fluent.EnterQueryScope())
             {
-                mock.CompareTo(otherObj);
-                mock.CompareTo(yetAnotherObj);
-            });
+                var mock = Substitute.For<IComparable>();
+                var otherObj = new Object();
+                var yetAnotherObj = new Object();
 
-            callingReceivedInAnyOrder.ShouldThrow<CallSequenceNotFoundException>();
+                mock.CompareTo(otherObj);
+
+                Action callingReceivedInAnyOrder = () => Fluent.ReceivedInAnyOrder(() =>
+                {
+                    mock.CompareTo(otherObj);
+                    mock.CompareTo(yetAnotherObj);
+                });
+
+                callingReceivedInAnyOrder.ShouldThrow<CallSequenceNotFoundException>();
+            }
         }
 
         [Test]
         public void ReceivedInAnyOrderAcceptsCallsWithFluentSpec()
         {
-            Fluent.Init();
-
-            var mock = Substitute.For<IComparable<string>>();
-
-            mock.CompareTo("b");
-            mock.CompareTo("a");
-
-            Fluent.ReceivedInAnyOrder(() =>
+            using (Fluent.EnterQueryScope())
             {
-                mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("a")));
-                mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("b")));
-            });
+                var mock = Substitute.For<IComparable<string>>();
+
+                mock.CompareTo("b");
+                mock.CompareTo("a");
+
+                Fluent.ReceivedInAnyOrder(() =>
+                {
+                    mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("a")));
+                    mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("b")));
+                });
+            }
         }
 
         [Test]
         public void ReceivedInAnyOrderRejectsMissingCallWithFluentSpec()
         {
-            Fluent.Init();
-
-            var mock = Substitute.For<IComparable<string>>();
-
-            mock.CompareTo("b");
-
-            Action callingReceivedInAnyOrder = () => Fluent.ReceivedInAnyOrder(() =>
+            using (Fluent.EnterQueryScope())
             {
-                mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("a")));
-                mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("b")));
-            });
+                var mock = Substitute.For<IComparable<string>>();
 
-            callingReceivedInAnyOrder.ShouldThrow<CallSequenceNotFoundException>();
+                mock.CompareTo("b");
+
+                Action callingReceivedInAnyOrder = () => Fluent.ReceivedInAnyOrder(() =>
+                {
+                    mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("a")));
+                    mock.CompareTo(Fluent.Match<string>(s => s.Should().Be("b")));
+                });
+
+                callingReceivedInAnyOrder.ShouldThrow<CallSequenceNotFoundException>();
+            }
         }
 
         [Test]
         public async Task ReceivedInAnyOrderAcceptsAsyncCallsMadeOutOfOrder()
         {
-            Fluent.Init();
-
-            var mock = Substitute.For<IAsyncInterface>();
-            mock.AnotherMethodAsync().Returns(Task.FromResult(2));
-
-            await mock.SomeMethodAsync("djir");
-            await mock.AnotherMethodAsync();
-            await mock.SomeMethodAsync("yoyo");
-
-            await Fluent.ReceivedInAnyOrder(async () =>
+            using (Fluent.EnterQueryScope())
             {
-                await mock.SomeMethodAsync(Fluent.Match<string>(s => s.Should().Contain("yo")));
+                var mock = Substitute.For<IAsyncInterface>();
+                mock.AnotherMethodAsync().Returns(Task.FromResult(2));
+
+                await mock.SomeMethodAsync("djir");
                 await mock.AnotherMethodAsync();
-                await mock.SomeMethodAsync(Fluent.Match<string>(s => s.Should().Contain("djir")));
-            });
+                await mock.SomeMethodAsync("yoyo");
+
+                await Fluent.ReceivedInAnyOrder(async () =>
+                {
+                    await mock.SomeMethodAsync(Fluent.Match<string>(s => s.Should().Contain("yo")));
+                    await mock.AnotherMethodAsync();
+                    await mock.SomeMethodAsync(Fluent.Match<string>(s => s.Should().Contain("djir")));
+                });
+            }
         }
 
         [Test]
         public async Task ReceivedInAnyOrderRejectsMissingAsyncCall()
         {
-            Fluent.Init();
-
-            var mock = Substitute.For<IAsyncInterface>();
-            mock.AnotherMethodAsync().Returns(Task.FromResult(2));
-
-            await mock.SomeMethodAsync("djir");
-            await mock.AnotherMethodAsync();
-
-            Func<Task> callingReceivedInAnyOrder = () => Fluent.ReceivedInAnyOrder(async () =>
+            using (Fluent.EnterQueryScope())
             {
-                await mock.SomeMethodAsync(Fluent.Match<string>(s => s.Should().Contain("yo")));
-                await mock.AnotherMethodAsync();
-                await mock.SomeMethodAsync(Fluent.Match<string>(s => s.Should().Contain("djir")));
-            });
+                var mock = Substitute.For<IAsyncInterface>();
+                mock.AnotherMethodAsync().Returns(Task.FromResult(2));
 
-            callingReceivedInAnyOrder.ShouldThrow<CallSequenceNotFoundException>();
+                await mock.SomeMethodAsync("djir");
+                await mock.AnotherMethodAsync();
+
+                Func<Task> callingReceivedInAnyOrder = () => Fluent.ReceivedInAnyOrder(async () =>
+                {
+                    await mock.SomeMethodAsync(Fluent.Match<string>(s => s.Should().Contain("yo")));
+                    await mock.AnotherMethodAsync();
+                    await mock.SomeMethodAsync(Fluent.Match<string>(s => s.Should().Contain("djir")));
+                });
+
+                callingReceivedInAnyOrder.ShouldThrow<CallSequenceNotFoundException>();
+            }
         }
 
         /// <summary>
-        /// Since it is not easy to unset a fluent context, it should still support vanilla
-        /// <see cref="Received.InOrder(Action)"/> queries.
+        /// Should still support vanilla <see cref="Received.InOrder(Action)"/> queries.
         /// </summary>
         [Test]
         public void VanillaQueryingIsStillSupported()
         {
-            Fluent.Init();
-
-            var mock = Substitute.For<IComparable>();
-            object x = new Object(), y = new Object();
-
-            mock.CompareTo(x);
-            mock.CompareTo(y);
-
-            Received.InOrder(() =>
+            using (Fluent.EnterQueryScope())
             {
+                var mock = Substitute.For<IComparable>();
+                object x = new Object(), y = new Object();
+
                 mock.CompareTo(x);
                 mock.CompareTo(y);
-            });
+
+                Received.InOrder(() =>
+                {
+                    mock.CompareTo(x);
+                    mock.CompareTo(y);
+                });
+            }
         }
     }
 }

--- a/FluentAssertionsEx.UnitTest/packages.config
+++ b/FluentAssertionsEx.UnitTest/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="4.2.1" targetFramework="net46" />
-  <package id="NSubstitute" version="1.9.2.0" targetFramework="net46" />
+  <package id="FluentAssertions" version="4.11.0" targetFramework="net46" />
+  <package id="NSubstitute" version="1.10.0.0" targetFramework="net46" />
   <package id="NUnit" version="2.6.4" targetFramework="net46" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net46" />
 </packages>

--- a/FluentAssertionsEx/Extensions/FluentAssertionsExtensions.cs
+++ b/FluentAssertionsEx/Extensions/FluentAssertionsExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using FluentAssertions.Collections;
+using FluentAssertions.Primitives;
 using HivePeople.FluentAssertionsEx.Assertions;
 
 namespace HivePeople.FluentAssertionsEx.Extensions

--- a/FluentAssertionsEx/FluentAssertionsEx.csproj
+++ b/FluentAssertionsEx/FluentAssertionsEx.csproj
@@ -30,16 +30,16 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.11.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.11.0\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.2.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.2.1\lib\net45\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=4.11.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.11.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute, Version=1.9.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\packages\NSubstitute.1.9.2.0\lib\net45\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -60,6 +60,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="NSubstitute\Query\FluentQuery.cs" />
     <Compile Include="NSubstitute\Query\FluentQuerySubstitutionContext.cs" />
+    <Compile Include="Support\ActionDisposable.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="FluentAssertionsEx.nuspec" />

--- a/FluentAssertionsEx/Properties/AssemblyInfo.cs
+++ b/FluentAssertionsEx/Properties/AssemblyInfo.cs
@@ -25,8 +25,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0.7")]
+[assembly: AssemblyVersion("0.1.0.8")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-alpha7")]
+[assembly: AssemblyInformationalVersion("1.0.0-alpha8")]

--- a/FluentAssertionsEx/Support/ActionDisposable.cs
+++ b/FluentAssertionsEx/Support/ActionDisposable.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information. 
+
+// This file has been copied from the excellent Reactive-Extensions project, specifically:
+// https://github.com/Reactive-Extensions/Rx.NET/blob/master/Rx.NET/Source/System.Reactive.Core/Reactive/Disposables/AnonymousDisposable.cs
+
+// The file has been modified for use in this project.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace FluentAssertionsEx.Support
+{
+    /// <summary>
+    /// Represents an Action-based disposable.
+    /// </summary>
+    public sealed class ActionDisposable : IDisposable
+    {
+        private volatile Action _dispose;
+
+        /// <summary>
+        /// Constructs a new disposable with the given action used for disposal.
+        /// </summary>
+        /// <param name="dispose">Disposal action which will be run upon calling Dispose.</param>
+        public ActionDisposable(Action dispose)
+        {
+            Debug.Assert(dispose != null);
+
+            _dispose = dispose;
+        }
+
+        /// <summary>
+        /// Calls the disposal action if and only if the current instance hasn't been disposed yet.
+        /// </summary>
+        public void Dispose()
+        {
+#pragma warning disable 0420
+            var dispose = Interlocked.Exchange(ref _dispose, null);
+#pragma warning restore 0420
+
+            if (dispose != null)
+            {
+                dispose();
+            }
+        }
+    }
+}

--- a/FluentAssertionsEx/packages.config
+++ b/FluentAssertionsEx/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="4.2.1" targetFramework="net46" />
-  <package id="NSubstitute" version="1.9.2.0" targetFramework="net46" />
+  <package id="FluentAssertions" version="4.11.0" targetFramework="net46" />
+  <package id="NSubstitute" version="1.10.0.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
- fix: since the custom FluentQuerySubstitutionContext was found to break
  substitution of delegates under some conditions, we have decided to
  remove Fluent.Init in favor of Fluent.EnterQueryScope that returns an
  IDisposable restoring the current context upon disposal; this is then
  intended to be combined with the using-statement in order to scope the
  change of current context to the method, where it is needed
