### PR TITLE
[TSS-585] Added a selection rule

### DIFF
--- a/FluentAssertionsEx.UnitTest/FluentAssertionsEx.UnitTest.csproj
+++ b/FluentAssertionsEx.UnitTest/FluentAssertionsEx.UnitTest.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Assertions\CollectionAssertionsTest.cs" />
     <Compile Include="NSubstitute\FluentTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SelectionRules\NonInheritedPublicPropertiesSelectionRuleTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/FluentAssertionsEx.UnitTest/Properties/AssemblyInfo.cs
+++ b/FluentAssertionsEx.UnitTest/Properties/AssemblyInfo.cs
@@ -25,8 +25,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0.2")]
+[assembly: AssemblyVersion("0.1.0.9")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-alpha2")]
+[assembly: AssemblyInformationalVersion("1.0.0-alpha9")]

--- a/FluentAssertionsEx.UnitTest/SelectionRules/NonInheritedPublicPropertiesSelectionRuleTest.cs
+++ b/FluentAssertionsEx.UnitTest/SelectionRules/NonInheritedPublicPropertiesSelectionRuleTest.cs
@@ -1,0 +1,86 @@
+﻿using FluentAssertions;
+using HivePeople.FluentAssertionsEx.SelectionRules;
+using NUnit.Framework;
+
+namespace FluentAssertionsEx.UnitTest.SelectionRules
+{
+    [TestFixture]
+    public class NonInheritedPublicPropertiesSelectionRuleTest
+    {
+        class Base
+        {
+            public string InheritedProp { get; set; }
+        }
+
+        class Leaf : Base
+        {
+            public Leaf() : this(0) { }
+
+            public Leaf(int privatePropValue)
+            {
+                this.PrivateProp = privatePropValue;
+            }
+
+            private int PrivateProp { get; set; }
+            public int PublicField;
+            public string DeclaredPublicProp { get; set; }
+        }
+
+        [Test]
+        public void ExcludesInheritedProperties()
+        {
+            var leaf1 = new Leaf
+            {
+                InheritedProp = "thisIsNotEqual",
+                DeclaredPublicProp = "thisIsEqual"
+            };
+
+            var leaf2 = new Leaf
+            {
+                InheritedProp = "toThisOtherValue",
+                DeclaredPublicProp = "thisIsEqual"
+            };
+
+            leaf1.ShouldBeEquivalentTo(leaf2, options => options.Using(new NonInheritedPublicPropertiesSelectionRule()));
+        }
+
+        [Test]
+        public void ExcludesPrivateProperties()
+        {
+            var leaf1 = new Leaf(privatePropValue: 1)
+            {
+                DeclaredPublicProp = "same"
+            };
+            var leaf2 = new Leaf(privatePropValue: 2)
+            {
+                DeclaredPublicProp = "same"
+            };
+
+            leaf1.ShouldBeEquivalentTo(leaf2, options => options.Using(new NonInheritedPublicPropertiesSelectionRule()));
+        }
+
+        [Test]
+        public void CannotCombineWithOtherSelectionRules()
+        {
+            var leaf1 = new Leaf
+            {
+                PublicField = 1,
+                InheritedProp = "thisIsEqual",
+                DeclaredPublicProp = "thisIsEqual"
+            };
+
+            var leaf2 = new Leaf
+            {
+                PublicField = 2,
+                InheritedProp = "thisIsEqual",
+                DeclaredPublicProp = "thisIsEqual"
+            };
+
+            // This should fail because PublicField is different
+            leaf1.ShouldBeEquivalentTo(leaf2, options => options.IncludingFields().Using(new NonInheritedPublicPropertiesSelectionRule()));
+
+            // Order doesn't matter, it still doesn't fail as it should
+            leaf1.ShouldBeEquivalentTo(leaf2, options => options.Using(new NonInheritedPublicPropertiesSelectionRule()).IncludingFields());
+        }
+    }
+}

--- a/FluentAssertionsEx/FluentAssertionsEx.csproj
+++ b/FluentAssertionsEx/FluentAssertionsEx.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="NSubstitute\Query\FluentQuery.cs" />
     <Compile Include="NSubstitute\Query\FluentQuerySubstitutionContext.cs" />
+    <Compile Include="SelectionRules\NonInheritedPublicPropertiesSelectionRule.cs" />
     <Compile Include="Support\ActionDisposable.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/FluentAssertionsEx/Properties/AssemblyInfo.cs
+++ b/FluentAssertionsEx/Properties/AssemblyInfo.cs
@@ -25,8 +25,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.0.8")]
+[assembly: AssemblyVersion("0.1.0.9")]
 
 // This is needed for specifying NuGet package version since AssemblyVersion does
 // not support semantic versioning.
-[assembly: AssemblyInformationalVersion("1.0.0-alpha8")]
+[assembly: AssemblyInformationalVersion("1.0.0-alpha9")]

--- a/FluentAssertionsEx/SelectionRules/NonInheritedPublicPropertiesSelectionRule.cs
+++ b/FluentAssertionsEx/SelectionRules/NonInheritedPublicPropertiesSelectionRule.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions.Equivalency;
+
+namespace HivePeople.FluentAssertionsEx.SelectionRules
+{
+    /// <summary>
+    /// Rule for including all public properties that are not inherited. Basically what you might expect
+    /// IncludeAllDeclaredProperties to do.
+    /// <remarks>This rule does not play nice with the other rules due to IncludesMembers returning true.</remarks>
+    /// </summary>
+    public class NonInheritedPublicPropertiesSelectionRule : IMemberSelectionRule
+    {
+        /// <summary>
+        /// We have to return true here or otherwise the user would have to call ExcludeProperties first, because all
+        /// public properties (including inherited ones) will be included by default.
+        /// </summary>
+        public bool IncludesMembers
+        {
+            get { return true; }
+        }
+
+        public IEnumerable<SelectedMemberInfo> SelectMembers(IEnumerable<SelectedMemberInfo> selectedMembers, ISubjectInfo context, IEquivalencyAssertionOptions config)
+        {
+            var publicNonInheritedProps = config.GetSubjectType(context)
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+                .Select(SelectedMemberInfo.Create);
+
+            return selectedMembers.Union(publicNonInheritedProps);
+        }
+
+        public override string ToString()
+        {
+            return "Include all public non-inherited properties";
+        }
+    }
+}


### PR DESCRIPTION
- add: selection rule for only including non-inherited public properties
  in object tree equivalency tests (ShouldBeEquivalentTo etc) as opposed
  to the default of including all public properties
